### PR TITLE
Support React 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "license": "MIT",
   "homepage": "https://github.com/dima-bu/react-time-input.git#readme",
   "peerDependencies": {
-    "react": "~0.13.x || ~0.14.x || ^15.0.0"
+    "react": "~0.13.x || ~0.14.x || ^15.0.0 || ^16.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.14.0",


### PR DESCRIPTION
We are using React 16 and react-time-input, and to avoid on having build warnings we added `^16.0.0` in supported React versions (in peerDependencies).

This can be tested as well by adding following line to applications' package.json:

`"react-time-input": "github:jussikinnula/react-time-input#0.0.17"`