### PR TITLE
Added one symbol hour support

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A simple react component for select time in format HH:mm",
   "main": "index.js",
   "scripts": {
-    "example": "webpack-dev-server --content-base ./example/ --config  ./example/webpack.config.js --colors --watch ",
+    "example": "webpack-dev-server --content-base ./example/ --config  ./example/webpack.config.js --colors --watch --host 127.0.0.1",
     "build": "babel src/timeInput.jsx -o index.js",
     "prepublish": "npm run build",
     "test": "karma start --auto-watch"
@@ -51,6 +51,6 @@
     "react-dom": "15.0.1",
     "react-hot-loader": "^1.3.0",
     "webpack": "1.13.0",
-    "webpack-dev-server": "^1.16.2"
+    "webpack-dev-server": "1.16.2"
   }
 }

--- a/src/timeInput.jsx
+++ b/src/timeInput.jsx
@@ -33,8 +33,7 @@ class TimeInput extends Component {
     }
 
     isValid (val) {
-        var letterArr = val.split(':').join('').split(''),
-            regexp = /^\d{0,2}?\:?\d{0,2}$/,
+        var regexp = /^\d{0,2}?\:?\d{0,2}$/,
             valArr = [];
 
         var [hoursStr, minutesStr] = val.split(':')
@@ -43,8 +42,16 @@ class TimeInput extends Component {
             return false
         }
 
-        const hours = Number(hoursStr)
-        const minutes = Number(minutesStr)
+        let hours = Number(hoursStr);
+
+        if (hours > 23 && minutesStr === undefined) {
+            let arr = hoursStr.split('');
+            hours = Number(arr[0]);
+            minutesStr = arr[1];
+            val = arr[0] + ':' + arr[1]
+        }
+
+        const minutes = Number(minutesStr);
 
         const isValidHour = (hour) => Number.isInteger(hours) && hours >= 0 && hours < 24
         const isValidMinutes = (minutes) => (Number.isInteger(minutes) && hours >= 0 && hours < 24) || Number.isNaN(minutes)
@@ -79,9 +86,14 @@ class TimeInput extends Component {
             return;
         }
         if (this.isValid(val)) {
-
-            if (val.length === 2 && this.lastVal.length !== 3 && val.indexOf(':') === -1) {
-                val = val + ':';
+            if (val.length === 2) {
+                if (Number(val) > 23) {
+                    let arr = val.split('');
+                    val = arr[0] + ':' + arr[1];
+                }
+                else if (this.lastVal.length !== 3 && val.indexOf(':') === -1) {
+                    val = val + ':';
+                }
             }
 
             if (val.length === 2 && this.lastVal.length === 3) {


### PR DESCRIPTION
There is a problem: when user inputs one numbered hour (3 for example) then he should to input the ':' sign. Otherwise no way to continue input. My pull request makes possible to input '30' without ':' and then script automatically ads ':' in the right place. 